### PR TITLE
Fix text contrast in recommendations section for accessibility (#2)

### DIFF
--- a/web/src/styles/main.css
+++ b/web/src/styles/main.css
@@ -40,6 +40,11 @@ body {
   body {
     background: linear-gradient(135deg, #2d3748 0%, #4a5568 100%);
   }
+  
+  .empty-message {
+    color: #e2e8f0;
+    background: rgba(26, 32, 44, 0.8);
+  }
 }
 
 /* Layout */
@@ -184,12 +189,13 @@ body {
 /* Empty states */
 .empty-message {
   text-align: center;
-  color: #666;
+  color: #2d3748;
   font-style: italic;
   padding: 2rem;
-  background: rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.9);
   border-radius: 0.5rem;
   backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
 }
 
 /* Validation messages */


### PR DESCRIPTION
## Summary
- Improved text contrast in light mode by using darker text (#2d3748) against stronger white background
- Added dark mode specific styling for empty message with light text (#e2e8f0) against dark background  
- Enhanced readability of "No recommendations yet" message in both light and dark modes
- Added border for better visual definition

## Test plan
- [x] Build frontend successfully
- [x] Verified changes improve text contrast in both light and dark modes
- [x] Ensured accessibility compliance with better color contrast ratios
- [x] Tested that the message is now clearly readable against gradient backgrounds

🤖 Generated with [Claude Code](https://claude.ai/code)